### PR TITLE
yq r replaced by yq e

### DIFF
--- a/messagebus/service-setup
+++ b/messagebus/service-setup
@@ -10,7 +10,7 @@ set -o errexit
 source ./settings.sh # configuration
 
 parameters=$(
-  yq r -j - << EO_PARAMETERS
+  yq e -j - << EO_PARAMETERS
 emname: "${instance}"
 options:
   management: true

--- a/usingappstudio/appstudiosetup
+++ b/usingappstudio/appstudiosetup
@@ -44,7 +44,7 @@ main() {
     setup
     configure
     install uuidgen "file://${PWD}/bin/uuidgen"
-    install yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+    install yq https://github.com/mikefarah/yq/releases/download/v4.5.0/yq_linux_amd64
     install jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
     install kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
 


### PR DESCRIPTION
The command `yq r` that is used in your `messagebus/service-setup` script is not available (at least in my installation). Instead you have to use `yq e` now.
I'm using `yq version 4.3.2`
